### PR TITLE
Firstcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,48 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# setuptools-scm version control
+src/cfpint/_version.py
+
+# Packages
+.Python
+build
+develop-eggs
+dist
+eggs
+.eggs
+parts
+sdist
+var
+*.egg-info
+.installed.cfg
+*.egg
+MANIFEST
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Eclipse / PyCharm / PyDev
+/.idea
+*.cover
+.project
+.pydevproject
+.settings
+
+# Docs
+docs/_build
+docs/api
+docs/details/api

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,66 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+files: |
+    (?x)(
+        docs\/.+\.py|
+        lib\/.+\.py|
+        tests\/.+\.py
+    )
+minimum_pre_commit_version: 1.21.0
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+        # Prevent giant files from being committed.
+    -   id: check-added-large-files
+        # Check whether files parse as valid Python.
+    -   id: check-ast
+        # Check for file name conflicts on case-insensitive filesytems.
+    -   id: check-case-conflict
+        # Check for files that contain merge conflict strings.
+    -   id: check-merge-conflict
+        # Check for debugger imports and py37+ `breakpoint()` calls in Python source.
+    -   id: debug-statements
+        # Don't commit to main branch.
+    -   id: no-commit-to-branch
+
+-   repo: https://github.com/codespell-project/codespell
+    rev: "v2.4.1"
+    hooks:
+    -   id: codespell
+        types_or: [asciidoc, python, markdown, rst]
+        additional_dependencies: [tomli]
+
+-   repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.1.0
+    hooks:
+    -   id: black
+        pass_filenames: false
+        args: [--config=./pyproject.toml, .]
+
+-   repo: https://github.com/PyCQA/flake8
+    rev: 7.3.0
+    hooks:
+    -   id: flake8
+        types: [file, python]
+
+-   repo: https://github.com/pycqa/isort
+    rev: 7.0.0
+    hooks:
+    -   id: isort
+        name: isort (python)
+
+-   repo: https://github.com/asottile/blacken-docs
+    rev: 1.20.0
+    hooks:
+    -   id: blacken-docs
+        types: [file, rst]
+
+-   repo: https://github.com/pycqa/pydocstyle
+    rev: 6.3.0
+    hooks:
+    -   id: pydocstyle
+        args: [--convention=numpy]
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     hooks:
     -   id: black
         pass_filenames: false
-        args: [--config=./pyproject.toml, .]
+        args: [.]
 
 -   repo: https://github.com/PyCQA/flake8
     rev: 7.3.0

--- a/src/cfpint/__init__.py
+++ b/src/cfpint/__init__.py
@@ -1,0 +1,10 @@
+"""Cfpint
+
+An extension of Pint units to support CF style units.
+
+Intended to replace cf-units and udunits with a pure Python CF units package.
+Also adds Pint compatibility.
+"""
+from ._core import Unit, UnitRegistry, REGISTRY
+
+__all__ = ["Unit", "UnitRegistry", "REGISTRY"]

--- a/src/cfpint/__init__.py
+++ b/src/cfpint/__init__.py
@@ -5,6 +5,7 @@ An extension of Pint units to support CF style units.
 Intended to replace cf-units and udunits with a pure Python CF units package.
 Also adds Pint compatibility.
 """
-from ._core import Unit, UnitRegistry, REGISTRY
 
-__all__ = ["Unit", "UnitRegistry", "REGISTRY"]
+from ._core import Unit, REGISTRY  #  , install_defaults
+
+__all__ = ["Unit", "REGISTRY"]  # , "install_defaults"]

--- a/src/cfpint/_cfarray_units_like.py
+++ b/src/cfpint/_cfarray_units_like.py
@@ -1,0 +1,147 @@
+"""
+Shamelessly stolen from cf_xarray.units
+At their version v0.10.11
+
+See : https://github.com/xarray-contrib/cf-xarray/blob/v0.10.11/cf_xarray/units.py
+
+As they say : "Module to provide unit support via pint approximating UDUNITS/CF."
+
+TODO: replace entirely with our own code.
+"""
+
+import functools
+import re
+import warnings
+
+import pint
+from packaging.version import Version
+
+# from .utils import emit_user_level_warning
+
+#
+# **Also** stolen from cf-xarray, to support below code,
+#
+def emit_user_level_warning(message, category=None):
+    """Emit a warning."""  #... at the user level by inspecting the stack trace.
+    # Here, just an emasculated version that **doesn't** fix the stack-level.
+    # stacklevel = find_stack_level()
+    warnings.warn(message, category=category) #, stacklevel=stacklevel)
+
+
+@pint.register_unit_format("cf")
+def short_formatter(unit, registry, **options):
+    """Return a CF-compliant unit string from a `pint` unit.
+
+    Parameters
+    ----------
+    unit : pint.UnitContainer
+        Input unit.
+    registry : pint.UnitRegistry
+        The associated registry
+    **options
+        Additional options (may be ignored)
+
+    Returns
+    -------
+    out : str
+        Units following CF-Convention, using symbols.
+    """
+    # pint 0.24.1 gives {"dimensionless": 1} for non-shortened dimensionless units
+    # CF uses "1" to denote fractions and dimensionless quantities
+    if unit == {"dimensionless": 1} or not unit:
+        return "1"
+
+    # If u is a name, get its symbol (same as pint's "~" pre-formatter)
+    # otherwise, assume a symbol (pint should have already raised on invalid units before this)
+    unit = pint.util.UnitsContainer(
+        {
+            registry._get_symbol(u) if u in registry._units else u: exp
+            for u, exp in unit.items()
+        }
+    )
+
+    # Change in formatter signature in pint 0.24
+    if Version(pint.__version__) < Version("0.24"):
+        args = (unit.items(),)
+    else:
+        # Numerators splitted from denominators
+        args = (
+            ((u, e) for u, e in unit.items() if e >= 0),
+            ((u, e) for u, e in unit.items() if e < 0),
+        )
+
+    out = pint.formatter(*args, as_ratio=False, product_fmt=" ", power_fmt="{}{}")
+    # To avoid potentiel unicode problems in netCDF. In both cases, this unit is not recognized by udunits
+    return out.replace("Δ°", "delta_deg")
+
+
+# ------
+# Reused with modification from MetPy under the terms of the BSD 3-Clause License.
+# Copyright (c) 2015,2017,2019 MetPy Developers.
+# Create registry, with preprocessors for UDUNITS-style powers (m2 s-2) and percent signs
+def make_registry(basetype) -> pint.UnitRegistry:
+    units: pint.UnitRegistry = basetype(
+        autoconvert_offset_to_baseunit=True,
+        preprocessors=[
+            functools.partial(
+                re.compile(
+                    r"(?<=[A-Za-z])(?![A-Za-z])(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])"
+                ).sub,
+                "**",
+            ),
+            lambda string: string.replace("%", "percent"),
+        ],
+        force_ndarray_like=True,
+    )
+    # ----- end block copied from metpy
+
+    # need to insert to make sure this is the first preprocessor
+    # This ensures we convert integer `1` to string `"1"`, as needed by pint.
+    units.preprocessors.insert(0, str)
+
+    # -----
+    units.define("percent = 0.01 = %")
+
+    # Define commonly encountered units (both CF and non-CF) not defined by pint
+    units.define("@alias meter = gpm")
+    # ----- end block copied from metpy
+
+    # -----
+    # The following redefinitions were copied from xclim under the terms of their Apache-2 license
+    # In pint, the default symbol for year is "a" which is not CF-compliant (stands for "are")
+    units.define("year = 365.25 * day = yr")
+
+    # Define commonly encountered units not defined by pint
+    units.define("@alias degC = C = deg_C = Celsius = degrees_Celsius")
+    units.define("@alias degK = deg_K")
+    units.define("@alias day = d")
+    units.define("@alias hour = h")  # Not the Planck constant...
+    units.define(
+        "degrees_north = degree = degrees_north = degrees_N = degreesN = degree_north = degree_N = degreeN"
+    )
+    units.define(
+        "degrees_east = degree = degrees_east = degrees_E = degreesE = degree_east = degree_E = degreeE"
+    )
+    # degrees for grid_longitude / grid_latitude for grid_mappings
+    units.define("degrees = degree = degrees")
+    units.define("[speed] = [length] / [time]")
+    # ----- end block copied from xclim
+
+    # Add other specific aliases (by cf_xarray developers)
+    units.define("practical_salinity_unit = [] = psu = PSU")
+
+    return units
+
+# # Enable pint's built-in matplotlib support
+# try:
+#     units.setup_matplotlib()
+# except ImportError:
+#     emit_user_level_warning(
+#         "Import(s) unavailable to set up matplotlib support...skipping this portion "
+#         "of the setup.",
+#         UserWarning,
+#     )
+# # end of vendored code from MetPy
+#
+# # Set as application registry
+# pint.set_application_registry(units)

--- a/src/cfpint/_cfarray_units_like.py
+++ b/src/cfpint/_cfarray_units_like.py
@@ -29,7 +29,7 @@ def emit_user_level_warning(message, category=None):
     warnings.warn(message, category=category)  # , stacklevel=stacklevel)
 
 
-@pint.register_unit_format("CF")
+@pint.register_unit_format("cfu")
 def short_formatter(unit, registry, **options):
     """Return a CF-compliant unit string from a `pint` unit.
 
@@ -80,7 +80,7 @@ def short_formatter(unit, registry, **options):
 # Reused with modification from MetPy under the terms of the BSD 3-Clause License.
 # Copyright (c) 2015,2017,2019 MetPy Developers.
 # Create registry, with preprocessors for UDUNITS-style powers (m2 s-2) and percent signs
-def make_registry(basetype) -> pint.UnitRegistry:
+def make_registry(basetype, **kwargs) -> pint.UnitRegistry:
     units: pint.UnitRegistry = basetype(
         autoconvert_offset_to_baseunit=True,
         preprocessors=[
@@ -93,6 +93,7 @@ def make_registry(basetype) -> pint.UnitRegistry:
             lambda string: string.replace("%", "percent"),
         ],
         force_ndarray_like=True,
+        **kwargs
     )
     # ----- end block copied from metpy
 

--- a/src/cfpint/_cfarray_units_like.py
+++ b/src/cfpint/_cfarray_units_like.py
@@ -18,17 +18,18 @@ from packaging.version import Version
 
 # from .utils import emit_user_level_warning
 
+
 #
 # **Also** stolen from cf-xarray, to support below code,
 #
 def emit_user_level_warning(message, category=None):
-    """Emit a warning."""  #... at the user level by inspecting the stack trace.
+    """Emit a warning."""  # ... at the user level by inspecting the stack trace.
     # Here, just an emasculated version that **doesn't** fix the stack-level.
     # stacklevel = find_stack_level()
-    warnings.warn(message, category=category) #, stacklevel=stacklevel)
+    warnings.warn(message, category=category)  # , stacklevel=stacklevel)
 
 
-@pint.register_unit_format("cf")
+@pint.register_unit_format("CF")
 def short_formatter(unit, registry, **options):
     """Return a CF-compliant unit string from a `pint` unit.
 
@@ -131,6 +132,7 @@ def make_registry(basetype) -> pint.UnitRegistry:
     units.define("practical_salinity_unit = [] = psu = PSU")
 
     return units
+
 
 # # Enable pint's built-in matplotlib support
 # try:

--- a/src/cfpint/_core.py
+++ b/src/cfpint/_core.py
@@ -62,13 +62,18 @@ class Unit(pint.Unit):
         """Support comparison between Units and strings.
 
         Pint Units do not support this, but cf_units did.
+
+        Also support comparison with other unit-like objects
+        -- specifically, regular pint.Unit and cf_units.Unit --
+        using string conversion.
         """
         if not isinstance(other, pint.Unit):
-            other = Unit(other)
+            # Use the string conversion of whatever it is to create a pint unit.
+            other = Unit(str(other))
         # plain string comparison works, because Pint does *not* "store" the original
         #  definition string (unlike udunits / cf_units).
-        result = str(self) == str(other)
-        return result
+        # Therefore the printed form is "canonical" anyway.
+        return str(self) == str(other)
 
     def __str__(self):
         result = super(pint.Unit, self).__str__()

--- a/src/cfpint/_core.py
+++ b/src/cfpint/_core.py
@@ -12,10 +12,78 @@ from ._cfarray_units_like import make_registry
 
 # Setup our own classes
 class Unit(pint.Unit):
+    _DATEUNITS_SIGNATURE = " since "
+
+    def __init__(self, *args, **kwargs):
+        """Expand unit coverage to include date units."""
+        startdate_str: str | None = None
+        calendar_str: str | None = None
+        if args and isinstance(args[0], str):
+            # Catch date units.
+            arg = args[0].lower()
+            if self._DATEUNITS_SIGNATURE in arg:
+                index = arg.index(self._DATEUNITS_SIGNATURE)
+                base_unit = arg[:index]
+                # NOTE: we are making no attempt to interpret the date string
+                #  : cf-units makes only token efforts to check for suitable content,
+                #  like expecting digits.
+                #  And *no* attempt to normalise the date formatting.
+                startdate_str = arg[index + len(self._DATEUNITS_SIGNATURE) :]
+                # NOTE: likewise, we don't really check calendar
+                #  N.B. cf_units (1) checks against a list of valid names, and (2)
+                #  normalises through a mapping of aliases.
+                # TODO: add some minimal checking of data+calendar, ~like cf_units
+                calendar_str = kwargs.pop("calendar", "default")
+                # Replace args[0]
+                args = [base_unit] + list(args[1:])
+        super().__init__(*args, **kwargs)
+        if self.dimensionality.get("[time]" != 1):
+            msg = (
+                f'Base unit "{base_unit}" of time reference "{arg}" '
+                "is not a time-like unit."
+            )
+            raise ValueError(msg)
+
+        self.startdate_string = startdate_str
+        self.calendar_string = calendar_str
+
+    def is_datelike(self) -> bool:
+        """Whether this unit is a time reference.
+
+        Note
+        ----
+        **Don't** copy the 'is_time_reference' name from cf_units, since we don't
+        support its other 'is_xxx' methods.
+        """
+        return self.startdate_string is not None
+
     def __eq__(self, other):
+        """Support comparison between Units and strings.
+
+        Pint Units do not support this, but cf_units did.
+        """
         if not isinstance(other, Unit):
             other = Unit(other)
+        # plain string comparison works, because Pint does *not* "store" the original
+        #  definition string (unlike udunits / cf_units).
         result = str(self) == str(other)
+        return result
+
+    def __str__(self):
+        result = super(pint.Unit, self).__str__()
+        if self.startdate_string is not None:
+            result += self._DATEUNITS_SIGNATURE + self.startdate_string
+            if self.calendar_string not in (None, "default"):
+                result += f", calendar='{self.calendar_string!s}'"
+        return result
+
+    def __repr__(self):
+        result = super(pint.Unit, self).__repr__()
+        if self.startdate_string is not None:
+            prefix, postfix = "<Unit('", "')>"
+            assert result.startswith(prefix)
+            assert result.endswith(postfix)
+            result = prefix + str(self) + postfix
         return result
 
 

--- a/src/cfpint/_core.py
+++ b/src/cfpint/_core.py
@@ -28,11 +28,12 @@ class Unit(pint.Unit):
                 #  : cf-units makes only token efforts to check for suitable content,
                 #  like expecting digits.
                 #  And *no* attempt to normalise the date formatting.
+                # TODO: validate this + normalise the formatting.
                 startdate_str = arg[index + len(self._DATEUNITS_SIGNATURE) :]
                 # NOTE: likewise, we don't really check calendar
                 #  N.B. cf_units (1) checks against a list of valid names, and (2)
                 #  normalises through a mapping of aliases.
-                # TODO: add some minimal checking of data+calendar, ~like cf_units
+                # TODO: add minimal checking of date+calendar, like cf_units or better
                 calendar_str = kwargs.pop("calendar", "default")
                 # Replace args[0]
                 args = [base_unit] + list(args[1:])
@@ -62,7 +63,7 @@ class Unit(pint.Unit):
 
         Pint Units do not support this, but cf_units did.
         """
-        if not isinstance(other, Unit):
+        if not isinstance(other, pint.Unit):
             other = Unit(other)
         # plain string comparison works, because Pint does *not* "store" the original
         #  definition string (unlike udunits / cf_units).
@@ -94,7 +95,9 @@ class CfpintRegistry(pint.registry.UnitRegistry):
 
 
 # Create our own registry, based on our own UnitRegistry subclass
-REGISTRY: CfpintRegistry = make_registry(CfpintRegistry)
+REGISTRY: CfpintRegistry = make_registry(
+    CfpintRegistry
+)  # include all 'normal' features
 
 # FOR NOW: failed to make selective installation work.
 # TODO: work out why and make "selectable" in future ??
@@ -104,5 +107,6 @@ REGISTRY: CfpintRegistry = make_registry(CfpintRegistry)
 #     pint.set_application_registry(REGISTRY)
 #
 # FOR NOW: just do it.
-REGISTRY.formatter.default_format = "CF"
 pint.set_application_registry(REGISTRY)
+pint.application_registry.default_system = "SI"
+pint.application_registry.default_format = "cfu"

--- a/src/cfpint/_core.py
+++ b/src/cfpint/_core.py
@@ -37,6 +37,10 @@ class Unit(pint.Unit):
                 calendar_str = kwargs.pop("calendar", "standard")
                 # Replace args[0]
                 args = [base_unit] + list(args[1:])
+        # Discard any spurious extra 'calendar' kwarg
+        #   - e.g. allow "calendar=None" with non-date unit
+        kwargs.pop("calendar", None)
+        # call the parent pint.Unit init.
         super().__init__(*args, **kwargs)
         if self.dimensionality.get("[time]" != 1):
             msg = (
@@ -96,7 +100,7 @@ class Unit(pint.Unit):
             assert result.endswith(postfix)
             result = prefix + str(self)
             # Temporarily, here but NOT in the repr (for cf-units compatibility = YUCK!)
-            if self.calendar_string not in (None, "default"):
+            if self.calendar_string not in (None, "standard", "default"):
                 # Note the handling of the "'"s
                 result += f"', calendar='{self.calendar_string!s}"
             result += postfix

--- a/src/cfpint/_core.py
+++ b/src/cfpint/_core.py
@@ -1,0 +1,24 @@
+"""
+Or own version of pint Units, for added CF support.
+
+Notably customised Unit and Registry classes.
+"""
+from typing import TypeAlias
+import pint
+
+from ._cfarray_units_like import make_registry
+
+# Setup our own classes
+
+class Unit(pint.Unit):
+    pass
+
+
+# See: https://pint.readthedocs.io/en/stable/advanced/custom-registry-class.html#custom-quantity-and-unit-class
+class CfpintRegistry(pint.registry.GenericUnitRegistry[pint.Quantity, pint.Unit]):
+    Quantity: TypeAlias = pint.Quantity
+    Unit: TypeAlias = Unit
+
+
+# Create our own registry, based on our own UnitRegistry subclass
+REGISTRY: CfpintRegistry = make_registry(CfpintRegistry)

--- a/src/cfpint/_core.py
+++ b/src/cfpint/_core.py
@@ -12,7 +12,11 @@ from ._cfarray_units_like import make_registry
 
 # Setup our own classes
 class Unit(pint.Unit):
-    pass
+    def __eq__(self, other):
+        if not isinstance(other, Unit):
+            other = Unit(other)
+        result = str(self) == str(other)
+        return result
 
 
 # See: https://pint.readthedocs.io/en/stable/advanced/custom-registry-class.html#custom-quantity-and-unit-class

--- a/src/cfpint/_core.py
+++ b/src/cfpint/_core.py
@@ -3,22 +3,34 @@ Or own version of pint Units, for added CF support.
 
 Notably customised Unit and Registry classes.
 """
+
 from typing import TypeAlias
 import pint
 
 from ._cfarray_units_like import make_registry
 
-# Setup our own classes
 
+# Setup our own classes
 class Unit(pint.Unit):
     pass
 
 
 # See: https://pint.readthedocs.io/en/stable/advanced/custom-registry-class.html#custom-quantity-and-unit-class
-class CfpintRegistry(pint.registry.GenericUnitRegistry[pint.Quantity, pint.Unit]):
+class CfpintRegistry(pint.registry.UnitRegistry):
     Quantity: TypeAlias = pint.Quantity
     Unit: TypeAlias = Unit
 
 
 # Create our own registry, based on our own UnitRegistry subclass
 REGISTRY: CfpintRegistry = make_registry(CfpintRegistry)
+
+# FOR NOW: failed to make selective installation work.
+# TODO: work out why and make "selectable" in future ??
+#
+# def install_defaults():
+#     REGISTRY.formatter.default_format = "CF"
+#     pint.set_application_registry(REGISTRY)
+#
+# FOR NOW: just do it.
+REGISTRY.formatter.default_format = "CF"
+pint.set_application_registry(REGISTRY)

--- a/src/cfpint/_core.py
+++ b/src/cfpint/_core.py
@@ -34,7 +34,7 @@ class Unit(pint.Unit):
                 #  N.B. cf_units (1) checks against a list of valid names, and (2)
                 #  normalises through a mapping of aliases.
                 # TODO: add minimal checking of date+calendar, like cf_units or better
-                calendar_str = kwargs.pop("calendar", "default")
+                calendar_str = kwargs.pop("calendar", "standard")
                 # Replace args[0]
                 args = [base_unit] + list(args[1:])
         super().__init__(*args, **kwargs)
@@ -67,20 +67,25 @@ class Unit(pint.Unit):
         -- specifically, regular pint.Unit and cf_units.Unit --
         using string conversion.
         """
-        if not isinstance(other, pint.Unit):
+        if not isinstance(other, self.__class__):
             # Use the string conversion of whatever it is to create a pint unit.
-            other = Unit(str(other))
+            # NOTE: forcing to own class enables derived subclasses to work the same.
+            other = self.__class__(str(other))
         # plain string comparison works, because Pint does *not* "store" the original
         #  definition string (unlike udunits / cf_units).
         # Therefore the printed form is "canonical" anyway.
+        # TODO: fix this to be calendar aware
+        #  - it's awkward because cf_units str() doesn't include calendar
+        #  - so, for now, neither does the iris CfpintUnit
         return str(self) == str(other)
 
     def __str__(self):
         result = super(pint.Unit, self).__str__()
         if self.startdate_string is not None:
             result += self._DATEUNITS_SIGNATURE + self.startdate_string
-            if self.calendar_string not in (None, "default"):
-                result += f", calendar='{self.calendar_string!s}'"
+            # TODO: we really ought to have this, but see temporary test_pintunit
+            # if self.calendar_string not in (None, "default"):
+            #     result += f", calendar='{self.calendar_string!s}'"
         return result
 
     def __repr__(self):
@@ -89,7 +94,12 @@ class Unit(pint.Unit):
             prefix, postfix = "<Unit('", "')>"
             assert result.startswith(prefix)
             assert result.endswith(postfix)
-            result = prefix + str(self) + postfix
+            result = prefix + str(self)
+            # Temporarily, here but NOT in the repr (for cf-units compatibility = YUCK!)
+            if self.calendar_string not in (None, "default"):
+                # Note the handling of the "'"s
+                result += f"', calendar='{self.calendar_string!s}"
+            result += postfix
         return result
 
 

--- a/src/cfpint/tests/test_basic.py
+++ b/src/cfpint/tests/test_basic.py
@@ -109,7 +109,7 @@ class TestDates:
         date_unit = Unit("days since 1970-01-01", **kwargs)
         assert (date_unit * 1).units == "days"
         assert date_unit.startdate_string == "1970-01-01"
-        expect_calendar = "default" if calendar is None else calendar
+        expect_calendar = calendar
         assert date_unit.calendar_string == expect_calendar
 
     @pytest.mark.parametrize("unitstr", ["m", "days", "hours since 1970"])

--- a/src/cfpint/tests/test_basic.py
+++ b/src/cfpint/tests/test_basic.py
@@ -1,0 +1,51 @@
+import pint
+import pytest
+
+# from cfpint import install_defaults
+from cfpint import Unit
+
+# TODO: want to know why this didn't work
+# @pytest.fixture(scope="session")
+# def install():
+#     install_defaults()
+
+
+class TestBasicCflike:
+    def test_non_cf(self):
+        m = Unit("m")
+        assert str(m) == "meter"
+
+    def test_cflike_product(self):
+        m = Unit("m.s-1")
+        assert str(m) == "meter/second"
+
+    def test_cflike_exponent(self):
+        m = Unit("kg.s-2")
+        assert str(m) == "kilogram/second**2"
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "m s-2",
+            "m.s-2",
+            "m.s**-2",
+            "m/s2",
+            "m / s**2",
+            "m/s**2",
+            "m / s2",
+            "m/sec/s",
+            "m / s / s",
+            "meter / seconds**2",
+            "meters.s-2",
+        ],
+    )
+    def test_cflike_multistyle(self, expr):
+        """Test that a bunch of different styles all mean the same thing."""
+        ms = Unit(expr)
+        assert str(ms) == "meter/second**2"
+
+    def test_pintlike_properties(self):
+        ms = Unit("m.s-2")
+        assert isinstance(ms, pint.Unit)
+        assert ms.dimensionless is False
+        assert ms.dimensionality == {"[length]": 1, "[time]": -2}

--- a/src/cfpint/tests/test_basic.py
+++ b/src/cfpint/tests/test_basic.py
@@ -15,15 +15,15 @@ class TestBasicCflike:
 
     def test_non_cf(self):
         m = Unit("m")
-        assert str(m) == "meter"
+        assert str(m) == "m"
 
     def test_cflike_product(self):
         m = Unit("m.s-1")
-        assert str(m) == "meter/second"
+        assert str(m) == "m s-1"
 
     def test_cflike_exponent(self):
         m = Unit("kg.s-2")
-        assert str(m) == "kilogram/second**2"
+        assert str(m) == "kg s-2"
 
     @pytest.mark.parametrize(
         "expr",
@@ -44,7 +44,7 @@ class TestBasicCflike:
     def test_cflike_multistyle(self, expr):
         """Test that a bunch of different styles all mean the same thing."""
         ms = Unit(expr)
-        assert str(ms) == "meter/second**2"
+        assert str(ms) == "m s-2"
 
     def test_pintlike_properties(self):
         ms = Unit("m.s-2")
@@ -116,8 +116,9 @@ class TestDates:
     )
     def test_date_difference(self, other):
         m1 = Unit("hours since 1970")
-        diff = (1.0 * m1) - (1.0 * Unit(other))
-        diff_units = diff.units
+        # TODO: is this what we now need to do for "Unit arithmetic"?
+        # i.e. we need to make Quantities
+        diff_units = ((1.0 * m1) - (1.0 * Unit(other))).units
         assert isinstance(diff_units, Unit)
         assert diff_units == "hours"
         assert not diff_units.is_datelike()
@@ -127,7 +128,8 @@ class TestDates:
     def test_str_repr(self, calendar, method):
         kwargs = {} if calendar is None else {"calendar": calendar}
         date_unit = Unit("day since 1970", **kwargs)
-        expect = "day since 1970"
+        # TODO: fix this (d//days), but for now it is done in Iris ???
+        expect = "d since 1970"
         if calendar == "365_day":
             expect += ", calendar='365_day'"
         if method == "str":

--- a/src/cfpint/tests/test_basic.py
+++ b/src/cfpint/tests/test_basic.py
@@ -1,5 +1,6 @@
 import pint
 import pytest
+from cf_units import Unit as CFU_Unit
 
 # from cfpint import install_defaults
 from cfpint import Unit
@@ -91,6 +92,12 @@ class TestCompares:
         assert type(m1) is Unit
         assert type(m2) is not Unit
         assert type(m2) is pint.Unit
+        assert m1 == m2
+        assert m2 == m1
+
+    def test_eq_cfunit(self):
+        m1 = Unit("m")
+        m2 = CFU_Unit("m")
         assert m1 == m2
         assert m2 == m1
 

--- a/src/cfpint/tests/test_basic.py
+++ b/src/cfpint/tests/test_basic.py
@@ -11,6 +11,8 @@ from cfpint import Unit
 
 
 class TestBasicCflike:
+    """Basic behaviours copied from cf_xarray.unit."""
+
     def test_non_cf(self):
         m = Unit("m")
         assert str(m) == "meter"
@@ -49,3 +51,45 @@ class TestBasicCflike:
         assert isinstance(ms, pint.Unit)
         assert ms.dimensionless is False
         assert ms.dimensionality == {"[length]": 1, "[time]": -2}
+
+
+class TestCompares:
+    @pytest.fixture(params=["eq", "ne"])
+    def equal(self, request):
+        return request.param == "eq"
+
+    def test_eq_owntype(self, equal):
+        m1 = Unit("m")
+        m2 = Unit("metres") if equal else "secs"
+        assert m1 is not m2
+        if equal:
+            assert m1 == m2
+        else:
+            assert m1 != m2
+
+    def test_eq_string(self, equal):
+        m1 = Unit("m")
+        string = "meter" if equal else "second"
+        if equal:
+            assert m1 == string
+            assert m1 == "metre"  # alternative spelling, for good measure
+        else:
+            assert m1 != string
+
+    def test_string_eq(self, equal):
+        m1 = Unit("m")
+        string = "meter" if equal else "second"
+        if equal:
+            assert string == m1
+            assert "metres" == m1  # alternative spelling, for good measure
+        else:
+            assert string != m1
+
+    def test_eq_pintbasic(self):
+        m1 = Unit("m")
+        m2 = pint.Unit("m")
+        assert type(m1) is Unit
+        assert type(m2) is not Unit
+        assert type(m2) is pint.Unit
+        assert m1 == m2
+        assert m2 == m1

--- a/src/cfpint/tests/test_basic.py
+++ b/src/cfpint/tests/test_basic.py
@@ -93,3 +93,46 @@ class TestCompares:
         assert type(m2) is pint.Unit
         assert m1 == m2
         assert m2 == m1
+
+
+class TestDates:
+    @pytest.mark.parametrize("calendar", [None, "default", "365_day"])
+    def test_date(self, calendar):
+        kwargs = {} if calendar is None else {"calendar": calendar}
+        date_unit = Unit("days since 1970-01-01", **kwargs)
+        assert (date_unit * 1).units == "days"
+        assert date_unit.startdate_string == "1970-01-01"
+        expect_calendar = "default" if calendar is None else calendar
+        assert date_unit.calendar_string == expect_calendar
+
+    @pytest.mark.parametrize("unitstr", ["m", "days", "hours since 1970"])
+    def test_is_datelike(self, unitstr):
+        unit = Unit(unitstr)
+        assert unit.is_datelike() == (" since " in unitstr)
+
+    @pytest.mark.parametrize(
+        "other",
+        ["days since 1970", "days since 1900"],
+    )
+    def test_date_difference(self, other):
+        m1 = Unit("hours since 1970")
+        diff = (1.0 * m1) - (1.0 * Unit(other))
+        diff_units = diff.units
+        assert isinstance(diff_units, Unit)
+        assert diff_units == "hours"
+        assert not diff_units.is_datelike()
+
+    @pytest.mark.parametrize("method", ["str", "repr"])
+    @pytest.mark.parametrize("calendar", [None, "default", "365_day"])
+    def test_str_repr(self, calendar, method):
+        kwargs = {} if calendar is None else {"calendar": calendar}
+        date_unit = Unit("day since 1970", **kwargs)
+        expect = "day since 1970"
+        if calendar == "365_day":
+            expect += ", calendar='365_day'"
+        if method == "str":
+            result = str(date_unit)
+        else:
+            expect = f"<Unit('{expect}')>"
+            result = repr(date_unit)
+        assert result == expect

--- a/src/cfpint/tests/test_basic.py
+++ b/src/cfpint/tests/test_basic.py
@@ -109,7 +109,7 @@ class TestDates:
         date_unit = Unit("days since 1970-01-01", **kwargs)
         assert (date_unit * 1).units == "days"
         assert date_unit.startdate_string == "1970-01-01"
-        expect_calendar = calendar
+        expect_calendar = "standard" if calendar is None else calendar
         assert date_unit.calendar_string == expect_calendar
 
     @pytest.mark.parametrize("unitstr", ["m", "days", "hours since 1970"])
@@ -137,8 +137,8 @@ class TestDates:
         date_unit = Unit("day since 1970", **kwargs)
         # TODO: fix this (d//days), but for now it is done in Iris ???
         expect = "d since 1970"
-        if calendar == "365_day":
-            expect += ", calendar='365_day'"
+        if calendar == "365_day" and method != "str":
+            expect += "', calendar='365_day"
         if method == "str":
             result = str(date_unit)
         else:


### PR DESCRIPTION
Delivery point of sprint spike 
https://github.com/orgs/SciTools/projects/56/views/2?pane=issue&itemId=157413549

notes
  * sort-of working with "parts of" Iris tests [at this point](https://github.com/pp-mo/iris/tree/FEATURE_cfpint_spike1)
    * can at least save + roundtrip a basic netcdf file with hybrid-height in it.
  * aiming at "clean" split between desired-cfpint behaviour and iris-only behaviour
     (which may or may not require creating a custom Registry type)

REFERENCE: stored in https://github.com/pp-mo/cfpint/tree/firstcode_spike1